### PR TITLE
Add SSH key exists

### DIFF
--- a/arm-image-installer
+++ b/arm-image-installer
@@ -301,6 +301,12 @@ if [ ! -e "$MEDIA" ]; then
 	exit 1
 fi
 
+# SSH key exists
+if [ ! -f "$SSH_KEY" ] && [ "$SSH_KEY" != "" ]; then
+	echo "Error: $SSH_KEY not found! Please choose an existing SSH key."
+	exit 1
+fi
+
 # Last chance to back out
 echo ""
 echo "====================================================="


### PR DESCRIPTION
Currently it's hard to tell if the SSH key was successfully added or not, which has left me and other users confused and frustrated as we've not been able to SSH into our devices after the installation, when we've used path like `~/.ssh/id_ed25519.pub` for the key which doesn't actually resolve to the key's location (I'm a bash noob so I don't know how to fix that).

This patch will cancel the installation immediately if the key doesn't exist and tell the user to use another path.

Here's a test:

```bash
$ sudo ./arm-image-installer \
    --image=/home/mikaeldui/Downloads/Fedora-Server-41-1.4.aarch64.raw.xz --resizefs \
    --target=rpi3 --media=/dev/mmcblk0 --addkey=/home/mikaeldui/.ssh/nonexisting.pub 
Error: /home/mikaeldui/.ssh/nonexisting.pub not found! Please choose an existing SSH key.
```

And with `~`:
```bash
Error: ~/.ssh/id_ed25519.pub not found! Please choose an existing SSH key.
```

And with a working path it doesn't display any error.