### PR TITLE
Add support for setting cloned-mac-address via --wifi-cloned-mac argument

### DIFF
--- a/README
+++ b/README
@@ -13,15 +13,15 @@ ARM disk image for use with various hardware targets.
  - Remove the root password
  - Update U-Boot for a Target
  - Setup wifi connection, security options supported are `wpa-psk`(default) for WPA2(mostly used) and `sae` for WPA3.
- 
+
 Note that the list of supported devices is a list of devices that arm-image-installer
 supports setting up the early boot firmware, it does not indicate the level of
 support for the device in Fedora for things like kernel drivers, functionality like
 display, audio, USB or any other specific hardware feature.
 
-To add additional support, create a code snippet file 
-(bash script) in the "boards.d" subdirectory with the commands 
-needed to write U-Boot for the target board. 
+To add additional support, create a code snippet file
+(bash script) in the "boards.d" subdirectory with the commands
+needed to write U-Boot for the target board.
 
 Usage: arm-image-installer <options>
 
@@ -40,6 +40,8 @@ Optional
 	--wifi-ssid=SSID        - Wi-Fi SSID to configure
 	--wifi-pass=PASS        - Wi-Fi password to configure
 	--wifi-security=TYPE    - Wi-Fi security type (wpa-psk, sae)
+	--wifi-cloned-mac=MAC   - Wi-Fi cloned MAC setting (MAC address or
+	                         'preserve', 'permanent', 'random', 'stable', 'stable-ssid')
 	-y              - Assumes yes, will not wait for confirmation
 Help
 	--supported     - List of hardware we support writing out boot firmware

--- a/arm-image-installer
+++ b/arm-image-installer
@@ -19,23 +19,25 @@ Optional
 	--addconsole    - Add system console kernel parameter for the target
 	--addkey        - /path/to/ssh-public-key
 	--args          - Optional kernel parameters listed in quotes
-	--ign-url	- url for ignition configuration file (IoT)
+	--ign-url       - url for ignition configuration file (IoT)
 	--norootpass    - Set the root password to the empty string
 	--relabel       - SELinux relabel root filesystem on first boot
 	--resizefs      - Resize root filesystem to fill media device
-	--showboot	- Show boot messages, removes 'rhgb quiet' from kargs
+	--showboot      - Show boot messages, removes 'rhgb quiet' from kargs
 	--sysrq         - Enable System Request debugging of the kernel
 	--target=TARGET - target board for uboot
 	--wifi-ssid=SSID        - Wi-Fi SSID to configure
 	--wifi-pass=PASS        - Wi-Fi password to configure
 	--wifi-security=TYPE    - Wi-Fi security type (wpa-psk, sae)
+	--wifi-cloned-mac=MAC   - Wi-Fi cloned MAC setting (MAC address or
+	                         'preserve', 'permanent', 'random', 'stable', 'stable-ssid')
 	-y              - Assumes yes, will not wait for confirmation
 
 Help
 	--supported     - List of hardware we support writing out boot firmware
 	--version       - Display version and exit
 
-Example: $(basename ${0}) --image=Fedora-Rawhide.xz --target=pine64_plus --media=/dev/mmcblk0 --wifi-ssid=MY_SSID --wifi-pass=MY_PASSWORD
+Example: $(basename ${0}) --image=Fedora-Rawhide.xz --target=pine64_plus --media=/dev/mmcblk0 --wifi-ssid=MY_SSID --wifi-pass=MY_PASSWORD --wifi-cloned-mac=permanent
 
 "
 }
@@ -190,6 +192,23 @@ while [ $# -gt 0 ]; do
 				exit 1
 			fi
 			;;
+		--wifi-cloned-mac*)
+			if echo $1 | grep '=' >/dev/null ; then
+				WIFI_CLONED_MAC=$(echo $1 | sed 's/^--wifi-cloned-mac=//')
+			elif [ -n "$2" ]; then
+				WIFI_CLONED_MAC=$2
+				shift
+			else
+				# Default to 'permanent' if not set
+				WIFI_CLONED_MAC="permanent"
+			fi
+			# Validate the cloned MAC setting
+			if [[ ! "$WIFI_CLONED_MAC" =~ ^(preserve|permanent|random|stable|stable-ssid|[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5})$ ]]; then
+				echo "$(basename ${0}): Error - Invalid Wi-Fi cloned MAC setting: $WIFI_CLONED_MAC"
+				usage
+				exit 1
+			fi
+			;;
 		--ign-url)
                         if echo $1 | grep '=' >/dev/null ; then
                                 IGN_URL=$(echo $1 | sed 's/^--ign-url=//')
@@ -266,7 +285,7 @@ if [ "$MEDIA" = "" ]; then
 fi
 
 ROOTDISK="$(mount | grep "on / " | awk '{printf $1"\n"}')"
-case "$ROOTDISK" in  
+case "$ROOTDISK" in
   *nvme*)
     ROOTDISK="$(echo $ROOTDISK | head -c 10)"
     ;;
@@ -367,6 +386,10 @@ fi
 # wifi ssid to be added
 if [ "$WIFI_SSID" != "" ]; then
 	echo "= Wifi ssid: $WIFI_SSID will autoconnect on boot."
+fi
+# wifi cloned mac setting
+if [ "$WIFI_CLONED_MAC" != "" ]; then
+	echo "= Wi-Fi cloned MAC setting will be set to: $WIFI_CLONED_MAC"
 fi
 # User ssh key
 if [ "$SSH_KEY" != "" ]; then
@@ -695,6 +718,7 @@ type=wifi
 [wifi]
 mode=infrastructure
 ssid=${WIFI_SSID}
+cloned-mac-address=${WIFI_CLONED_MAC:-permanent}
 EOF
 
     # Add security configuration if a password is provided


### PR DESCRIPTION
## Add support for `--wifi-cloned-mac` to control MAC address policy

This PR adds a new argument `--wifi-cloned-mac` to allow users to control the `cloned-mac-address` setting for Wi-Fi provisioning.

Example usage:
```
arm-image-installer --image=/path/to/Fedora-IoT.raw.xz - -wifi-ssid=<wifi name> --wifi-pass=<wifi password> --wifi-security=wpa-psk --wifi-cloned-mac=permanent --args="net.ifnames=0"
```

Valid values:
- `permanent`, `preserve`, `random`, `stable`, `stable-ssid`
- A specific MAC address: `00:11:22:33:44:55`

**Reason for this change:**
In IoT scenarios, it's often necessary to have predictable, known MAC addresses for device identification, provisioning, or network access control (e.g., MAC filtering). This change gives users explicit control over the MAC policy at provisioning time.

Fedora 40’s system-wide MAC randomization policy:  
<https://discussion.fedoraproject.org/t/f40-change-proposal-wifi-mac-randomization-system-wide/99856>

Reference for accepted values:  
<https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html#nm-settings-nmcli.property.802-11-wireless.cloned-mac-address>

I have verified its functionality by run the command to install Fedora IoT to my Raspberry Pi 3B+ .