### PR TITLE
socs.d: am625: Make u-boot partition bootable

### DIFF
--- a/socs.d/am625
+++ b/socs.d/am625
@@ -17,11 +17,19 @@ cp -a /tmp/fw/* /tmp/fw_bk/
 umount /tmp/fw
 
 UUID="$(lsblk -no UUID $FIRMPART)"
-mkfs.vfat "$FIRMPART" &> /dev/null
+mkfs.vfat -F 32 "$FIRMPART" &> /dev/null
 if [ $? != 0 ] ; then
 	echo "ERROR: Firmware partition filesystem reformatting failed!"
 	cleanup
 fi
+
+DISK=$(echo "$FIRMPART" | sed -E 's/[0-9]+$//')
+PART=$(echo "$FIRMPART" | sed -E 's/^.*([0-9]+)$/\1/')
+
+echo "= Update Partition Table for ${DISK}: ${PART}"
+
+sfdisk --part-type $DISK $PART 0x0C
+sfdisk $DISK --activate $PART
 
 # restore the old filesystem UUID to match the /etc/fstab
 printf "\x${UUID:7:2}\x${UUID:5:2}\x${UUID:2:2}\x${UUID:0:2}" \


### PR DESCRIPTION
- When trying to use Fedora server 43 image, the first FAT partition where u-boot is supposed to be put is not marked as bootable. This seems to cause the image to not boot at all.
- Also update the partition table since we reformat the partition to FAT32. This is required since at least in case of Fedora server 43, the partition is FAT16 by default.