### PR TITLE
feat(multicast-support): add options hostname and multicast

### DIFF
--- a/arm-image-installer
+++ b/arm-image-installer
@@ -41,6 +41,7 @@ Optional
 	--wifi-ssid=SSID        - Wi-Fi SSID to configure
 	--wifi-pass=PASS        - Wi-Fi password to configure
 	--wifi-security=TYPE    - Wi-Fi security type (wpa-psk, sae)
+	--hostname=NAME         - Set system hostname
 	-y              - Assumes yes, will not wait for confirmation
 
 Help
@@ -198,6 +199,18 @@ while [ $# -gt 0 ]; do
 			# Validate the security type
 			if [[ "$WIFI_SECURITY" != "wpa-psk" && "$WIFI_SECURITY" != "sae" ]]; then
 				echo "$(basename ${0}): Error - Invalid Wi-Fi security type: $WIFI_SECURITY"
+				usage
+				exit 1
+			fi
+			;;
+		--hostname*)
+			if echo $1 | grep '=' >/dev/null ; then
+				SET_HOSTNAME=$(echo $1 | sed 's/^--hostname=//')
+			elif [ -n "$2" ]; then
+				SET_HOSTNAME=$2
+				shift
+			else
+				echo "$(basename ${0}): Error - '--hostname' expects an argument"
 				usage
 				exit 1
 			fi
@@ -368,7 +381,7 @@ fi
 # check only one ignition source was added
 if [ -n "$IGNITION" ] && [ -n "$IGN_URL" ]; then
         echo "Error: Please pick one ignition source, local or url."
-        exit 1
+	exit 1
 fi
 
 # Last chance to back out
@@ -426,6 +439,10 @@ fi
 # wifi ssid to be added
 if [ "$WIFI_SSID" != "" ]; then
 	echo "= Wifi ssid: $WIFI_SSID will autoconnect on boot."
+fi
+# hostname to be set
+if [ "$SET_HOSTNAME" != "" ]; then
+		echo "= Hostname: $SET_HOSTNAME"
 fi
 # User ssh key
 if [ "$SSH_KEY" != "" ]; then
@@ -808,6 +825,12 @@ EOF
 
     # Set file permissions
     chmod 600 ${PREFIX}/etc/NetworkManager/system-connections/$FILENAME
+fi
+
+# Configure hostname
+if [ "$SET_HOSTNAME" != "" ]; then
+	echo "= Setting hostname: $SET_HOSTNAME"
+	echo "$SET_HOSTNAME" > ${PREFIX}/etc/hostname
 fi
 
 # Add console

--- a/arm-image-installer
+++ b/arm-image-installer
@@ -42,6 +42,7 @@ Optional
 	--wifi-pass=PASS        - Wi-Fi password to configure
 	--wifi-security=TYPE    - Wi-Fi security type (wpa-psk, sae)
 	--hostname=NAME         - Set system hostname
+	--multicast             - Enable mDNS for hostname.local (requires --hostname)
 	-y              - Assumes yes, will not wait for confirmation
 
 Help
@@ -215,6 +216,9 @@ while [ $# -gt 0 ]; do
 				exit 1
 			fi
 			;;
+		--multicast)
+			MULTICAST=1
+			;;
 		--ign-url*)
                         if echo $1 | grep '=' >/dev/null ; then
                                 IGN_URL=$(echo $1 | sed 's/^--ign-url=//')
@@ -381,6 +385,12 @@ fi
 # check only one ignition source was added
 if [ -n "$IGNITION" ] && [ -n "$IGN_URL" ]; then
         echo "Error: Please pick one ignition source, local or url."
+        exit 1
+fi
+
+# multicast requires hostname
+if [ "$MULTICAST" = "1" ] && [ -z "$SET_HOSTNAME" ]; then
+	echo "Error: --multicast requires --hostname to be set."
 	exit 1
 fi
 
@@ -442,7 +452,11 @@ if [ "$WIFI_SSID" != "" ]; then
 fi
 # hostname to be set
 if [ "$SET_HOSTNAME" != "" ]; then
+	if [ "$MULTICAST" = "1" ]; then
+		echo "= Hostname: $SET_HOSTNAME.local (mDNS enabled)"
+	else
 		echo "= Hostname: $SET_HOSTNAME"
+	fi
 fi
 # User ssh key
 if [ "$SSH_KEY" != "" ]; then
@@ -831,6 +845,61 @@ fi
 if [ "$SET_HOSTNAME" != "" ]; then
 	echo "= Setting hostname: $SET_HOSTNAME"
 	echo "$SET_HOSTNAME" > ${PREFIX}/etc/hostname
+fi
+
+# Configure mDNS for hostname.local resolution
+if [ "$MULTICAST" = "1" ]; then
+	echo "= Enabling mDNS (multicast DNS) for $SET_HOSTNAME.local"
+
+	RESOLVED_CONF="${PREFIX}/etc/systemd/resolved.conf"
+	if [ -f "$RESOLVED_CONF" ]; then
+		if grep -q "^MulticastDNS=" "$RESOLVED_CONF"; then
+			sed -i 's/^MulticastDNS=.*/MulticastDNS=yes/' "$RESOLVED_CONF"
+		elif grep -q "^\[Resolve\]" "$RESOLVED_CONF"; then
+			sed -i '/^\[Resolve\]/a MulticastDNS=yes' "$RESOLVED_CONF"
+		else
+			printf "\n[Resolve]\nMulticastDNS=yes\n" >> "$RESOLVED_CONF"
+		fi
+	else
+		mkdir -p "$(dirname "$RESOLVED_CONF")"
+		cat > "$RESOLVED_CONF" <<-EOF
+[Resolve]
+MulticastDNS=yes
+EOF
+	fi
+
+	# Enable mDNS on Wi-Fi connection if configured
+	if [ "$WIFI_SSID" != "" ]; then
+		WIFI_CONN="${PREFIX}/etc/NetworkManager/system-connections/$FILENAME"
+		if [ -f "$WIFI_CONN" ]; then
+			if grep -q "^\[connection\]" "$WIFI_CONN"; then
+				sed -i '/^\[connection\]/a mdns=2' "$WIFI_CONN"
+			fi
+		fi
+	fi
+
+	# Create NetworkManager conf.d drop-in for default mDNS on new connections
+	mkdir -p "${PREFIX}/etc/NetworkManager/conf.d"
+	cat > "${PREFIX}/etc/NetworkManager/conf.d/mdns.conf" <<-EOF
+[connection]
+connection.mdns=2
+EOF
+
+	# Open firewall for mDNS (UDP 5353)
+	FIREWALLD_SERVICES="${PREFIX}/etc/firewalld/zones"
+	if [ -d "${PREFIX}/etc/firewalld" ]; then
+		mkdir -p "$FIREWALLD_SERVICES"
+		cat > "${FIREWALLD_SERVICES}/public.xml" <<-EOF
+<?xml version="1.0" encoding="utf-8"?>
+<zone>
+  <short>Public</short>
+  <description>Public zone with mDNS enabled</description>
+  <service name="dhcpv6-client"/>
+  <service name="ssh"/>
+  <service name="mdns"/>
+</zone>
+EOF
+	fi
 fi
 
 # Add console


### PR DESCRIPTION
Enable devices to be reachable via hostname.local on the local network using systemd-resolved's native mDNS capability. No additional packages required on Fedora IoT.

--hostname=NAME sets /etc/hostname
--multicast enables mDNS announcing (requires --hostname):
  - Configures MulticastDNS=yes in resolved.conf
  - Sets connection.mdns=2 in NetworkManager
  - Opens UDP 5353 in firewalld