### PR TITLE
Don't truncate image files when updating uboot.

### DIFF
--- a/socs.d/AllWinner
+++ b/socs.d/AllWinner
@@ -1,5 +1,5 @@
 # write uboot
 echo "= Writing u-boot-sunxi-with-spl.bin ...."
-dd if=$PREFIX/usr/share/uboot/$TARGET/u-boot-sunxi-with-spl.bin of=$MEDIA bs=1024 seek=8; sync
+dd if=$PREFIX/usr/share/uboot/$TARGET/u-boot-sunxi-with-spl.bin of=$MEDIA bs=1024 seek=8 conv=notrunc; sync
 # set console for allwinner
 SYSCON=ttyS0,115200

--- a/socs.d/rk35xx
+++ b/socs.d/rk35xx
@@ -1,5 +1,5 @@
 # write uboot
 echo "= Writing u-boot-rockchip.bin for $TARGET .... on media $MEDIA"
-dd if=$PREFIX/usr/share/uboot/$TARGET/u-boot-rockchip.bin of=$MEDIA seek=64; sync
+dd if=$PREFIX/usr/share/uboot/$TARGET/u-boot-rockchip.bin of=$MEDIA seek=64 conv=notrunc; sync
 # set console for Rockchips
 SYSCON=ttyS2,1500000n8

--- a/socs.d/rk3xxx
+++ b/socs.d/rk3xxx
@@ -1,5 +1,5 @@
 # write uboot
 echo "= Writing u-boot-rockchip.bin for $TARGET .... on media $MEDIA"
-dd if=$PREFIX/usr/share/uboot/$TARGET/u-boot-rockchip.bin of=$MEDIA seek=64; sync
+dd if=$PREFIX/usr/share/uboot/$TARGET/u-boot-rockchip.bin of=$MEDIA seek=64 conv=notrunc; sync
 # set console for Rockchips
 SYSCON=ttyS2,1500000n8


### PR DESCRIPTION
Passes "conv=notrunc" to dd in socs.d scripts to prevent image truncation when update-uboot is called with a file as the --media argument.